### PR TITLE
Field url was added to content objects of type post and page.

### DIFF
--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -9,6 +9,8 @@
                               "ASDF"
                               "REPL"
                               "HTTP"))
+  (0.3.0 2024-05-27
+         "* Field `url` was added to `content` objects of type `post` and `page`. It contains a full URL of the page and can be used as `canonical` URL in templates.")
   (0.2.0 2024-05-26
          "* `Excerpt` field was added to the `content` objects such as posts and pages. It can be used in the description HTML tags.
           * Filters `remove-html-tags` and `first-line` were added to the template engine base on Closure Templates.")

--- a/src/content.lisp
+++ b/src/content.lisp
@@ -378,6 +378,8 @@
 (defmethod template-vars ((site site) (content content-from-file) &key (hash (dict)))
   (setf (gethash "title" hash)
         (content-title content)
+        (gethash "url" hash)
+        (object-url site content :full t)
         (gethash "html" hash)
         (content-html content)
         (gethash "excerpt" hash)


### PR DESCRIPTION
It contains a full URL of the page and can be used as canonical URL in templates.