### PR TITLE
Fixed sitemap.xml format

### DIFF
--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -10,6 +10,8 @@
                               "REPL"
                               "HTML"
                               "HTTP"))
+  (0.8.1 2025-11-17
+         "* Fixed sitemap.xml format. Previously priority might be rendered as 0.5f0 when `*read-default-float-format*` is bound to `double-float`. See [related issue in cl-sitemaps](https://github.com/egao1980/cl-sitemaps/issues/3).")
   (0.8.0 2025-10-05
          "* Now STATICL/INDEX/PAGINATED:PAGINATED-INDEX renders an empty index page in case if there is no items.")
   (0.7.1 2025-09-05

--- a/src/plugins/sitemap.lisp
+++ b/src/plugins/sitemap.lisp
@@ -61,11 +61,15 @@
 
 
 (defmethod write-content-to-stream ((site site) (sitemap sitemap-file) (stream stream))
-  (render-sitemap (loop for item in (sitemap-content sitemap)
-                        collect (make-url (object-url site item :full t)
-                                          :changefreq :weekly
-                                          :priority 0.5))
-                  :stream stream))
+  (let ((*read-default-float-format*
+          ;; Until this bug will be fixed:
+          ;; https://github.com/egao1980/cl-sitemaps/issues/3
+          'single-float))
+    (render-sitemap (loop for item in (sitemap-content sitemap)
+                          collect (make-url (object-url site item :full t)
+                                            :changefreq :weekly
+                                            :priority 0.5))
+                    :stream stream)))
 
 
 (defmethod staticl/pipeline:process-items ((site site) (node sitemap) content-items)


### PR DESCRIPTION
Previously priority might be rendered as 0.5f0 when `*read-default-float-format*` is bound to `double-float`.

See [related issue in cl-sitemaps](https://github.com/egao1980/cl-sitemaps/issues/3).